### PR TITLE
インスタみたいにチェックボックスのイベントを検知できるようにした #29

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -87,16 +87,24 @@ class GamingView(generic.TemplateView):
     def post(self, request, *args, **kwargs):
 
         context = {}
+        results = UserAnswers.objects.filter(user=request.user).last()  # テーブルの最後のクエリを抽出
+
+        # fetchで送信されるユーザーの解答をモデルに保存
         user_answer = request.POST.get('user-answer')  # 解答フォームから解答を受け取る
         print(f"'{user_answer}'と解答されました")
-        results = UserAnswers.objects.filter(user=request.user).last()  # テーブルの最後のクエリを抽出
         results.user_answer = user_answer  # ユーザーの解答を記録
+
+        # fetchで送信されるユーザーが選択した刺激語の順序をモデルに保存
+        u_order = request.POST.get('u-order')  # ユーザーが選択した刺激語の順序を受け取る
+        print(f"ユーザーが選択した順序は {u_order} です")
+        results.u_order = u_order
+
         results.save()  # 結果を保存
 
         # 質問がなくなった場合
         if len(request.session['qid_list']) == 0:
             print("ゲーム終了！")
-            return redirect('game:results')  # 結果画面に遷移
+            return redirect('/results/')
 
         # 質問がまだある場合
         else:
@@ -130,3 +138,10 @@ class ResultsView(generic.TemplateView):
         request.session['started'] = False
 
         return super().get(request, **kwargs)
+
+
+    # def post(self, request, *args, **kwargs):
+
+    #     request.session['started'] = False
+
+    #     return super().get(request, **kwargs)

--- a/static/js/checkbox_queue.js
+++ b/static/js/checkbox_queue.js
@@ -1,4 +1,4 @@
-let queue = [];
+var queue = [];
 const stim_dict = {
     'stimulus-1': '1',
     'stimulus-2': '2',
@@ -20,10 +20,16 @@ function handleCheckboxChange(event) {
 
     // 変化があった checkbox を取得
     var changed_checkbox = this;
-    var changed_checkbox_id = changed_checkbox.id;
-    console.log(stim_dict[changed_checkbox_id]);
+    var changed_checkbox_id = stim_dict[changed_checkbox.id];
 
-    // console.log(queue)
-    // 以下、必要な処理を記述する
+    // チェックが外された場合、リストから刺激語のidを削除
+    if (queue.includes(changed_checkbox_id) === true){
+        var index = queue.indexOf(changed_checkbox_id)
+        queue.splice(index, 1)
+    }
+    // チェックがされた場合、リストに刺激語のidを追加
+    else{
+        queue.push(changed_checkbox_id)
+    }
+    console.log(queue);
 }
-

--- a/static/js/checkbox_queue.js
+++ b/static/js/checkbox_queue.js
@@ -1,4 +1,11 @@
-let a = 0
+let queue = [];
+const stim_dict = {
+    'stimulus-1': '1',
+    'stimulus-2': '2',
+    'stimulus-3': '3',
+    'stimulus-4': '4',
+    'stimulus-5': '5',
+}
 
 // inputタグのうち type が checkbox のもの全てを対象
 const checkboxes = document.querySelectorAll('input[type=checkbox]');
@@ -10,7 +17,13 @@ checkboxes.forEach((checkbox) => {
 
 // チェックボックスの状態が変更されたときの処理を定義する関数
 function handleCheckboxChange(event) {
-    console.log(a); // チェックされている場合はtrue、されていない場合はfalse
-    a += 1;
+
+    // 変化があった checkbox を取得
+    var changed_checkbox = this;
+    var changed_checkbox_id = changed_checkbox.id;
+    console.log(stim_dict[changed_checkbox_id]);
+
+    // console.log(queue)
     // 以下、必要な処理を記述する
 }
+

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -19,7 +19,9 @@ answer_form.addEventListener('submit', (e) => {
 	const answer = document.getElementById('user-answer')
 	// URLのクエリパラメータを管理
 	const body = new URLSearchParams()
-	body.append('user-answer', answer.value)
+	body.append('user-answer', answer.value)  // ユーザーの解答
+    var u_order = "53142"  // こんな感じで刺激語の順序を文字列にしてdjango側に渡す
+    body.append('u-order', u_order)  // ユーザーが選択した刺激語の順序
 
 	// fetch API の登場! リロードしなくても画面の一部を更新できるようになる
 	fetch('', {


### PR DESCRIPTION
チェックボックスの動きを検知し、それに合わせて何番目にチェックされたかどうかを記憶できるようにした。以下やらなきゃいけないこと
- 解答送信ボタンを押されたら(=POSTメソッドが実行されたら)に対してバリデーションを行いたい。formが空欄だったり、全ての刺激語にチェックが入っていなかったりしたら送信できないようにするような。
- 解答送信ボタンを押されたら、ユーザーが選択した刺激語の順序が格納されているリストである`queue`をクリアな状態にして、チェックボックスのチェックも外されるようにしたい。
- サーバー側に`queue_checkbox.js`の`queue`を送りたいため、`fetch.js`内に`queue`をexport(転送)できるようにしたい。

上の3つができればフロントの機能的なところは大丈夫かな