### PR TITLE
ユーザーが選択した順序の変数を異なるjsファイル間でやり取りできるようにした

### DIFF
--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -56,8 +56,8 @@
 </form>
 
 <!--ゲーム中の処理を行うjsを読み込む-->
-<script type="text/javascript" src="{% static 'js/fetch.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/checkbox_queue.js' %}"></script>
+<script type="module" src="{% static 'js/fetch.js' %}"></script>
+<script type="module" src="{% static 'js/checkbox_queue.js' %}"></script>
 
 
 {% endblock %}

--- a/static/js/checkbox_queue.js
+++ b/static/js/checkbox_queue.js
@@ -5,7 +5,7 @@ const stim_dict = {
     'stimulus-3': '3',
     'stimulus-4': '4',
     'stimulus-5': '5',
-}
+};
 
 // inputタグのうち type が checkbox のもの全てを対象
 const checkboxes = document.querySelectorAll('input[type=checkbox]');
@@ -32,4 +32,6 @@ function handleCheckboxChange(event) {
         queue.push(changed_checkbox_id)
     }
     console.log(queue);
-}
+};
+
+export {queue};  // queue 変数を fetch.js で使えるようにする

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -1,3 +1,5 @@
+import { queue } from './checkbox_queue.js';
+
 // FetchAPI を使用するときは、CSRF に関する処理が必要になります。
 const getCookie = (name) => {
 	if (document.cookie && document.cookie !== '') {
@@ -8,11 +10,11 @@ const getCookie = (name) => {
 			}
 		}
 	}
-}
-const csrftoken = getCookie('csrftoken')
+};
+const csrftoken = getCookie('csrftoken');
 
 // 解答する
-const answer_form = document.getElementById('answer-form')
+const answer_form = document.getElementById('answer-form');
 answer_form.addEventListener('submit', (e) => {
 	e.preventDefault()
 	const url = '{% url "gaming" %}'
@@ -20,7 +22,7 @@ answer_form.addEventListener('submit', (e) => {
 	// URLのクエリパラメータを管理
 	const body = new URLSearchParams()
 	body.append('user-answer', answer.value)  // ユーザーの解答
-    var u_order = "53142"  // こんな感じで刺激語の順序を文字列にしてdjango側に渡す
+    var u_order = queue.join('')  // こんな感じで刺激語の順序を文字列にしてdjango側に渡す
     body.append('u-order', u_order)  // ユーザーが選択した刺激語の順序
 
 	// fetch API の登場! リロードしなくても画面の一部を更新できるようになる
@@ -51,4 +53,4 @@ answer_form.addEventListener('submit', (e) => {
 	.catch((error) => {
 			console.log(error)
 	})
-})
+});


### PR DESCRIPTION
#36 fetch.jsでユーザーが刺激語の貢献度を選択した変数である`queue`を管理しているが、その変数をfetch.jsに転送したかったためそれを実装した。
fcb15f3e3411a0f18ffb53d61b38ec4f57759ec0
上記コミットで実装したように、`type='module'`でjsファイルを読み込むようにすると`import/export`ができるようになり、変数や関数の受け渡しができるようになる。