### PR TITLE
残りの質問数をステートレスに管理するようにした

### DIFF
--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -6,6 +6,10 @@
 {% block contents %}
 <a href="{% url 'game:results' %}" class="text-blue-800 underline">結果画面へ</a>
 
+<script>
+	var left_questions = {{left_questions | safe }};
+</script>
+
 <!-- 5つの刺激語をcheckbox形式で羅列している -->
 <div class="flex items-center mb-4">
 	<input

--- a/game/views.py
+++ b/game/views.py
@@ -13,6 +13,7 @@ from typing import List, Tuple, Dict, Any, Union
 
 
 STIMULI_NUM = 5  # 刺激語の数
+QUESTIONS_NUM = 3  # 本当は87だがテスト用に
 STIMULI_HEADER = [f"stimulus_{i+1}" for i in range(STIMULI_NUM)]
 STIMULI_ORDER = [i for i in range(STIMULI_NUM)]
 RAMDOM_ORDER = False  # False ならばDBに載っている刺激語の順に提示
@@ -31,7 +32,6 @@ class IndexView(generic.TemplateView):
             request.session['visited'] = True
 
         request.session['started'] = False  # ゲームがスタートしたらTrueにする
-        request.session['qid_list'] = [1, 2, 4]  # 解答しなければいけない質問(qid)のリスト(仮)
 
         # ランダムに刺激語を提示する場合
         if RAMDOM_ORDER:
@@ -59,6 +59,8 @@ class GamingView(generic.TemplateView):
     def get(self, request, *args, **kwargs):
 
         context = {}
+        left_questions = QUESTIONS_NUM  # ユーザーが答えなければいけない質問の残数
+        context['left_questions'] = left_questions
 
         # 1問目
         if request.session['started'] == False:
@@ -67,7 +69,7 @@ class GamingView(generic.TemplateView):
             start_datetime = localtime(timezone.now())  # 開始の日付時刻を記憶
             request.session['started'] = True  # ゲーム中ならTrue
             request.session['session_id'] = start_datetime.strftime("%Y%m%d%H%M%S")  # 同ユーザーの異なるゲーム(セッション)を識別
-            qid = request.session['qid_list'].pop(0)  # qid_listからqidをpopする. このリストが空になったらゲーム終了.
+            qid = QUESTIONS_NUM - left_questions + 1  # ユーザーが答える質問のID
 
             # データベースに最初の質問IDを登録
             UserAnswers.objects.create(
@@ -109,17 +111,19 @@ class GamingView(generic.TemplateView):
         results.u_order = u_order
 
         results.save()  # 結果を保存
+        left_questions = int(request.POST.get('left-questions'))
+        left_questions -= 1
 
         # 質問がなくなった場合
-        if len(request.session['qid_list']) == 0:
+        if left_questions == 0:
             print("ゲーム終了！")
             return redirect('/results/')
 
         # 質問がまだある場合
         else:
-
-            print(f"残り{len(request.session['qid_list'])}問です")
-            qid = request.session['qid_list'].pop(0)  # qid_listからqidをpopする. このリストが空になったらゲーム終了.
+            print(f"残り{left_questions}問です")
+            context['left_questions'] = left_questions
+            qid = QUESTIONS_NUM - left_questions + 1  # ユーザーが答える質問のID
 
             # 次の質問を作る
             UserAnswers.objects.create(
@@ -140,7 +144,7 @@ class GamingView(generic.TemplateView):
             context['q_sentence'] = q_sentence[-1]  # ユーザーに提示する質問文
             print(context)
 
-        return JsonResponse(context)
+            return JsonResponse(context)
 
 
 class ResultsView(generic.TemplateView):

--- a/game/views.py
+++ b/game/views.py
@@ -27,11 +27,9 @@ class IndexView(generic.TemplateView):
     def get(self, request, *args, **kwargs):
 
         # ログインしてから初めてタイトル画面を訪れた場合
-        if not 'visited' in request.session:
+        if not 'status' in request.session:
             print("Hello!")
-            request.session['visited'] = True
-
-        request.session['started'] = False  # ゲームがスタートしたらTrueにする
+            request.session['status'] = 1  # ログイン画面に訪れたことが一度でもあれば status に 2^0(1) を加算
 
         # ランダムに刺激語を提示する場合
         if RAMDOM_ORDER:
@@ -63,11 +61,11 @@ class GamingView(generic.TemplateView):
         context['left_questions'] = left_questions
 
         # 1問目
-        if request.session['started'] == False:
+        if request.session['status'] == 1:
 
             print("Game Start!")
             start_datetime = localtime(timezone.now())  # 開始の日付時刻を記憶
-            request.session['started'] = True  # ゲーム中ならTrue
+            request.session['status'] = 3  # ゲーム中なら status に 2^1(2) を加算
             request.session['session_id'] = start_datetime.strftime("%Y%m%d%H%M%S")  # 同ユーザーの異なるゲーム(セッション)を識別
             qid = QUESTIONS_NUM - left_questions + 1  # ユーザーが答える質問のID
 
@@ -153,7 +151,7 @@ class ResultsView(generic.TemplateView):
 
     def get(self, request, *args, **kwargs):
 
-        request.session['started'] = False
+        request.session['status'] = 1  # ゲーム中ではないので 2^1(2) を減算
 
         return super().get(request, **kwargs)
 

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -32,6 +32,7 @@ answer_form.addEventListener("submit", (e) => {
     body.append("user-answer", answer.value); // ユーザーの解答
     const u_order = queue.join(""); // こんな感じで刺激語の順序を文字列にしてdjango側に渡す
     body.append("u-order", u_order); // ユーザーが選択した刺激語の順序
+		body.append("left-questions", left_questions);
 
     // fetch API の登場! リロードしなくても画面の一部を更新できるようになる
     fetch("", {
@@ -54,8 +55,10 @@ answer_form.addEventListener("submit", (e) => {
         // 刺激語を更新 & チェクボックスをクリアな状態に
 				for (let i=0; i<NUM_STIM; i++){
 					checkbox_labels[i].innerText = response.stimuli[i];
-					checkboxes[i].checked = false;
+					// checkboxes[i].checked = false;  バグるためコメントアウトしておく
 				}
+				// ユーザーが答えなければいけない質問数を更新する
+				left_questions = response.left_questions;
 				// ユーザーが選択した刺激語の順序を記憶する配列もクリアに
 				queue = [];
       })


### PR DESCRIPTION
今まではサーバー側で全て管理していたが、ステートレスが好ましいということを知り、残数をリクエストとレスポンスに一々格納するようにした（これがいいのかはわからない）。同様に状態の管理もなるべく`session.`に格納しないように努力した。