### PR TITLE
チェックボックスと刺激語順序を格納する配列を毎回クリアにできるように修正

### DIFF
--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -7,7 +7,8 @@
 <a href="{% url 'game:results' %}" class="text-blue-800 underline">結果画面へ</a>
 
 <script>
-	var left_questions = {{left_questions | safe }};
+	var left_questions = {{left_questions | safe }};  // 残りの質問数
+	var queue = [];  // ユーザーが選択した刺激語の順序を格納
 </script>
 
 <!-- 5つの刺激語をcheckbox形式で羅列している -->

--- a/static/js/checkbox_queue.js
+++ b/static/js/checkbox_queue.js
@@ -1,4 +1,3 @@
-var queue = [];
 const stim_dict = {
     'stimulus-1': '1',
     'stimulus-2': '2',
@@ -33,5 +32,3 @@ function handleCheckboxChange(event) {
     }
     console.log(queue);
 };
-
-export {queue};  // queue 変数を fetch.js で使えるようにする

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -1,5 +1,3 @@
-import { queue } from "./checkbox_queue.js";
-
 // FetchAPI を使用するときは、CSRF に関する処理が必要になります。
 const getCookie = (name) => {
   if (document.cookie && document.cookie !== "") {
@@ -55,7 +53,7 @@ answer_form.addEventListener("submit", (e) => {
         // 刺激語を更新 & チェクボックスをクリアな状態に
 				for (let i=0; i<NUM_STIM; i++){
 					checkbox_labels[i].innerText = response.stimuli[i];
-					// checkboxes[i].checked = false;  バグるためコメントアウトしておく
+					checkboxes[i].checked = false;
 				}
 				// ユーザーが答えなければいけない質問数を更新する
 				left_questions = response.left_questions;


### PR DESCRIPTION
#35 解答を送信したら、全てのチェックボックスのチェックが外され、また、ユーザーが刺激語の役に立った思う順番を記憶する配列`queue`もクリアな状態にするように修正した。

複数のjsファイルにまたがって使うような変数は、テンプレート(htmlファイル)内のscript上で定義すると、グローバル変数として使いやすい。