### PR TITLE
ゲーム画面から結果画面に遷移できるようにした

### DIFF
--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -9,6 +9,7 @@
 <script>
 	var left_questions = {{left_questions | safe }};  // 残りの質問数
 	var queue = [];  // ユーザーが選択した刺激語の順序を格納
+	const url_results = {% url 'game:results' %};  // 結果画面に遷移するためのurlもここで定義
 </script>
 
 <!-- 5つの刺激語をcheckbox形式で羅列している -->

--- a/game/views.py
+++ b/game/views.py
@@ -111,16 +111,17 @@ class GamingView(generic.TemplateView):
         results.save()  # 結果を保存
         left_questions = int(request.POST.get('left-questions'))
         left_questions -= 1
+        context['left_questions'] = left_questions
 
         # 質問がなくなった場合
         if left_questions == 0:
             print("ゲーム終了！")
-            return redirect('/results/')
+            # return redirect('/results/')
+            return JsonResponse(context)
 
         # 質問がまだある場合
         else:
             print(f"残り{left_questions}問です")
-            context['left_questions'] = left_questions
             qid = QUESTIONS_NUM - left_questions + 1  # ユーザーが答える質問のID
 
             # 次の質問を作る

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -20,7 +20,6 @@ answer_form.addEventListener("submit", (e) => {
   // 全ての刺激語がチェックされている場合は、フォームを送信する
   if (queue.length >= NUM_STIM) {
 
-    const url = '{% url "gaming" %}';
     const answer = document.getElementById("user-answer");
 		const checkboxes = document.getElementsByName('stimulus');
 		const checkbox_labels = document.getElementsByName('label-stimulus');
@@ -29,6 +28,7 @@ answer_form.addEventListener("submit", (e) => {
     const body = new URLSearchParams();
     body.append("user-answer", answer.value); // ユーザーの解答
     const u_order = queue.join(""); // こんな感じで刺激語の順序を文字列にしてdjango側に渡す
+		console.log("ユーザーが選択した刺激語の順序は "+u_order+" です");
     body.append("u-order", u_order); // ユーザーが選択した刺激語の順序
 		body.append("left-questions", left_questions);
 
@@ -47,6 +47,12 @@ answer_form.addEventListener("submit", (e) => {
         // JSON形式に変換
         return response.json();
       })
+			// 残りの質問が0かどうかを判定し、0なら結果画面へ遷移
+			.then((response) => {
+				if (response.left_questions == 0) window.location.href = url_results;
+				return response;
+			})
+			// 0ではないので次の問題を用意
       .then((response) => {
         // フォームをクリア
         answer.value = "";


### PR DESCRIPTION
#22 質問が全て終わり、gaming.htmlからresults.htmlに遷移させる時、サーバー側(views.py)で遷移を行うようにしていたが、fetchAPIを使うとうまく遷移できない(?)ので、jsファイル側で残質問数に応じて画面遷移を制御させるようにした。 8da7b09e134af4b76f5e833f3825c1a5e9ea6720