### PR TITLE
チェックボックス上にユーザーが選択した刺激語の順序を動的に表示可能に

### DIFF
--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -16,9 +16,9 @@
   <li>
     <input id="stimulus-1" type="checkbox" value="stimulus-1" name="stimulus" class="hidden peer">
     <label id="label-stimulus-1" for="stimulus-1" name="label-stimulus" class="checkbox-label">
-      <div class="block">
-        <div id="checkbox-icon-1" class="checkbox-icon"></div>
+      <div class="flex justify-start">
         <div class="w-full text-lg font-semibold">{{ stimuli.0 }}</div>
+        <div id="checkbox-icon-1" class="checkbox-icon"></div>
       </div>
     </label>
   </li>
@@ -26,9 +26,9 @@
   <li>
     <input id="stimulus-2" type="checkbox" value="stimulus-2" name="stimulus" class="hidden peer">
     <label id="label-stimulus-2" for="stimulus-2" name="label-stimulus" class="checkbox-label">
-      <div class="block">
-        <div id="checkbox-icon-2" class="checkbox-icon"></div>
+      <div class="flex justify-start">
         <div class="w-full text-lg font-semibold">{{ stimuli.1 }}</div>
+        <div id="checkbox-icon-2" class="checkbox-icon"></div>
       </div>
     </label>
   </li>
@@ -36,9 +36,9 @@
   <li>
     <input id="stimulus-3" type="checkbox" value="stimulus-3" name="stimulus" class="hidden peer">
     <label id="label-stimulus-3" for="stimulus-3" name="label-stimulus" class="checkbox-label">
-      <div class="block">
-        <div id="checkbox-icon-3" class="checkbox-icon"></div>
+      <div class="flex justify-start">
         <div class="w-full text-lg font-semibold">{{ stimuli.2 }}</div>
+        <div id="checkbox-icon-3" class="checkbox-icon"></div>
       </div>
     </label>
   </li>
@@ -46,9 +46,9 @@
   <li>
     <input id="stimulus-4" type="checkbox" value="stimulus-4" name="stimulus" class="hidden peer">
     <label id="label-stimulus-4" for="stimulus-4" name="label-stimulus" class="checkbox-label">
-      <div class="block">
-        <div id="checkbox-icon-4" class="checkbox-icon"></div>
+      <div class="flex justify-start">
         <div class="w-full text-lg font-semibold">{{ stimuli.3 }}</div>
+        <div id="checkbox-icon-4" class="checkbox-icon"></div>
       </div>
     </label>
   </li>
@@ -56,9 +56,9 @@
   <li>
     <input id="stimulus-5" type="checkbox" value="stimulus-5" name="stimulus" class="hidden peer">
     <label id="label-stimulus-5" for="stimulus-5" name="label-stimulus" class="checkbox-label">
-      <div class="block">
-        <div id="checkbox-icon-5" class="checkbox-icon"></div>
+      <div class="flex justify-start">
         <div class="w-full text-lg font-semibold">{{ stimuli.4 }}</div>
+        <div id="checkbox-icon-5" class="checkbox-icon"></div>
       </div>
     </label>
   </li>

--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -17,6 +17,7 @@
     <input id="stimulus-1" type="checkbox" value="stimulus-1" name="stimulus" class="hidden peer">
     <label id="label-stimulus-1" for="stimulus-1" name="label-stimulus" class="checkbox-label">
       <div class="block">
+        <div id="checkbox-icon-1" class="checkbox-icon"></div>
         <div class="w-full text-lg font-semibold">{{ stimuli.0 }}</div>
       </div>
     </label>
@@ -26,6 +27,7 @@
     <input id="stimulus-2" type="checkbox" value="stimulus-2" name="stimulus" class="hidden peer">
     <label id="label-stimulus-2" for="stimulus-2" name="label-stimulus" class="checkbox-label">
       <div class="block">
+        <div id="checkbox-icon-2" class="checkbox-icon"></div>
         <div class="w-full text-lg font-semibold">{{ stimuli.1 }}</div>
       </div>
     </label>
@@ -35,6 +37,7 @@
     <input id="stimulus-3" type="checkbox" value="stimulus-3" name="stimulus" class="hidden peer">
     <label id="label-stimulus-3" for="stimulus-3" name="label-stimulus" class="checkbox-label">
       <div class="block">
+        <div id="checkbox-icon-3" class="checkbox-icon"></div>
         <div class="w-full text-lg font-semibold">{{ stimuli.2 }}</div>
       </div>
     </label>
@@ -44,6 +47,7 @@
     <input id="stimulus-4" type="checkbox" value="stimulus-4" name="stimulus" class="hidden peer">
     <label id="label-stimulus-4" for="stimulus-4" name="label-stimulus" class="checkbox-label">
       <div class="block">
+        <div id="checkbox-icon-4" class="checkbox-icon"></div>
         <div class="w-full text-lg font-semibold">{{ stimuli.3 }}</div>
       </div>
     </label>
@@ -53,6 +57,7 @@
     <input id="stimulus-5" type="checkbox" value="stimulus-5" name="stimulus" class="hidden peer">
     <label id="label-stimulus-5" for="stimulus-5" name="label-stimulus" class="checkbox-label">
       <div class="block">
+        <div id="checkbox-icon-5" class="checkbox-icon"></div>
         <div class="w-full text-lg font-semibold">{{ stimuli.4 }}</div>
       </div>
     </label>

--- a/game/templates/gaming.html
+++ b/game/templates/gaming.html
@@ -17,7 +17,7 @@
     <input id="stimulus-1" type="checkbox" value="stimulus-1" name="stimulus" class="hidden peer">
     <label id="label-stimulus-1" for="stimulus-1" name="label-stimulus" class="checkbox-label">
       <div class="flex justify-start">
-        <div class="w-full text-lg font-semibold">{{ stimuli.0 }}</div>
+        <div class="checkbox-label-content">{{ stimuli.0 }}</div>
         <div id="checkbox-icon-1" class="checkbox-icon"></div>
       </div>
     </label>
@@ -27,7 +27,7 @@
     <input id="stimulus-2" type="checkbox" value="stimulus-2" name="stimulus" class="hidden peer">
     <label id="label-stimulus-2" for="stimulus-2" name="label-stimulus" class="checkbox-label">
       <div class="flex justify-start">
-        <div class="w-full text-lg font-semibold">{{ stimuli.1 }}</div>
+        <div class="checkbox-label-content">{{ stimuli.1 }}</div>
         <div id="checkbox-icon-2" class="checkbox-icon"></div>
       </div>
     </label>
@@ -37,7 +37,7 @@
     <input id="stimulus-3" type="checkbox" value="stimulus-3" name="stimulus" class="hidden peer">
     <label id="label-stimulus-3" for="stimulus-3" name="label-stimulus" class="checkbox-label">
       <div class="flex justify-start">
-        <div class="w-full text-lg font-semibold">{{ stimuli.2 }}</div>
+        <div class="checkbox-label-content">{{ stimuli.2 }}</div>
         <div id="checkbox-icon-3" class="checkbox-icon"></div>
       </div>
     </label>
@@ -47,7 +47,7 @@
     <input id="stimulus-4" type="checkbox" value="stimulus-4" name="stimulus" class="hidden peer">
     <label id="label-stimulus-4" for="stimulus-4" name="label-stimulus" class="checkbox-label">
       <div class="flex justify-start">
-        <div class="w-full text-lg font-semibold">{{ stimuli.3 }}</div>
+        <div class="checkbox-label-content">{{ stimuli.3 }}</div>
         <div id="checkbox-icon-4" class="checkbox-icon"></div>
       </div>
     </label>
@@ -57,7 +57,7 @@
     <input id="stimulus-5" type="checkbox" value="stimulus-5" name="stimulus" class="hidden peer">
     <label id="label-stimulus-5" for="stimulus-5" name="label-stimulus" class="checkbox-label">
       <div class="flex justify-start">
-        <div class="w-full text-lg font-semibold">{{ stimuli.4 }}</div>
+        <div class="checkbox-label-content">{{ stimuli.4 }}</div>
         <div id="checkbox-icon-5" class="checkbox-icon"></div>
       </div>
     </label>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -21,6 +21,10 @@ Custimize styles using @apply
   @apply hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700;
 }
 
+.checkbox-label-content {
+	@apply w-full text-lg font-semibold;
+}
+
 .checkbox-icon {
   @apply ml-5;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -21,8 +21,8 @@ Custimize styles using @apply
   @apply hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700;
 }
 
-.checkbox_icon {
-  @apply text-right;
+.checkbox-icon {
+  @apply ml-5;
 }
 
 /*

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,7 +22,7 @@ Custimize styles using @apply
 }
 
 .checkbox_icon {
-  @apply rounded-full;
+  @apply text-right;
 }
 
 /*

--- a/static/css/style_dist.css
+++ b/static/css/style_dist.css
@@ -1677,8 +1677,8 @@ Custimize styles using @apply
   color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 
-.checkbox_icon {
-  text-align: right;
+.checkbox-icon {
+  margin-left: 1.25rem;
 }
 
 /*

--- a/static/css/style_dist.css
+++ b/static/css/style_dist.css
@@ -1677,6 +1677,13 @@ Custimize styles using @apply
   color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 
+.checkbox-label-content {
+  width: 100%;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
 .checkbox-icon {
   margin-left: 1.25rem;
 }

--- a/static/css/style_dist.css
+++ b/static/css/style_dist.css
@@ -1678,7 +1678,7 @@ Custimize styles using @apply
 }
 
 .checkbox_icon {
-  border-radius: 9999px;
+  text-align: right;
 }
 
 /*

--- a/static/js/checkbox_queue.js
+++ b/static/js/checkbox_queue.js
@@ -24,10 +24,25 @@ function handleCheckboxChange(event) {
   if (queue.includes(changed_checkbox_id) === true) {
     var index = queue.indexOf(changed_checkbox_id);
     queue.splice(index, 1);
+
+    // チェックが外されたチェックボックスの表示番号を削除
+    var unchecked_checkbox_icon = document.getElementById("checkbox-icon-" + changed_checkbox_id);
+    unchecked_checkbox_icon.innerText = "";
+
+    // 全てのチェック済みチェックボックスの表示番号を付け替える
+    if (queue.length > 0){
+      for (let i=0; i<queue.length; i++){
+        var checkbox_icon = document.getElementById("checkbox-icon-" + queue[i]);
+        checkbox_icon.innerText = i + 1;
+      }
+    }
   }
   // チェックがされた場合、リストに刺激語のidを追加
   else {
     queue.push(changed_checkbox_id);
+    // 今チェックされたチェックボックスに表示番号を付ける
+    var checkbox_icon = document.getElementById("checkbox-icon-" + changed_checkbox_id);
+    checkbox_icon.innerText = queue.indexOf(changed_checkbox_id) + 1;
   }
   console.log(queue);
 }

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -21,7 +21,8 @@ answer_form.addEventListener("submit", (e) => {
   if (queue.length >= NUM_STIM) {
     const answer = document.getElementById("user-answer");
     const checkboxes = document.getElementsByName("stimulus");
-    const checkbox_labels = document.getElementsByName("label-stimulus");
+    const checkbox_labels = document.querySelectorAll("div.checkbox-label-content");
+    const checkbox_icons = document.querySelectorAll("div.checkbox-icon");
 
     // URLのクエリパラメータを管理
     const body = new URLSearchParams();
@@ -55,10 +56,11 @@ answer_form.addEventListener("submit", (e) => {
       .then((response) => {
         // フォームをクリア
         answer.value = "";
-        // 刺激語を更新 & チェクボックスをクリアな状態に
+        // 刺激語を更新 & チェックボックスをクリアな状態に
         for (let i = 0; i < NUM_STIM; i++) {
           checkbox_labels[i].innerText = response.stimuli[i];
           checkboxes[i].checked = false;
+          checkbox_icons[i].innerText = "";
         }
         // ユーザーが答えなければいけない質問数を更新する
         left_questions = response.left_questions;


### PR DESCRIPTION
#29 Tailwind CSSを使ってチェックボックスは見えなくして、その代わりにラベルを押せるようにした。